### PR TITLE
fix #1 (stata: break legend on space)

### DIFF
--- a/stata/binslogit.ado
+++ b/stata/binslogit.ado
@@ -622,7 +622,7 @@ program define binslogit, eclass
 		    else {
 			   local byvalname `: label `bylabel' `byval''
 			}
-			local byvalnamelist `byvalnamelist' `byvalname'
+			local byvalnamelist `" `byvalnamelist' `"`byvalname'"' "'
 		}
 		if (`bynum'>1) {
 		   mata: `byindex'=`byvec':==`byval'

--- a/stata/binsprobit.ado
+++ b/stata/binsprobit.ado
@@ -620,7 +620,7 @@ program define binsprobit, eclass
 		    else {
 			   local byvalname `: label `bylabel' `byval''
 			}
-			local byvalnamelist `byvalnamelist' `byvalname'
+			local byvalnamelist `" `byvalnamelist' `"`byvalname'"' "'
 		}
 		if (`bynum'>1) {
 		   mata: `byindex'=`byvec':==`byval'

--- a/stata/binspwc.ado
+++ b/stata/binspwc.ado
@@ -547,7 +547,7 @@ program define binspwc, eclass
 		else {
 		   local byvalname `: label `bylabel' `byval''
 		}
-		local byvalnamelist `byvalnamelist' `byvalname'
+		local byvalnamelist `" `byvalnamelist' `"`byvalname'"' "'
 		
 		mata: `byindex'=`byvec':==`byval'
 		mata: `xsub'=select(`xvec',`byindex'); `ysub'=select(`yvec', `byindex')

--- a/stata/binsreg.ado
+++ b/stata/binsreg.ado
@@ -631,7 +631,7 @@ program define binsreg, eclass
 		    else {
 			   local byvalname `: label `bylabel' `byval''
 			}
-			local byvalnamelist `byvalnamelist' `byvalname'
+			local byvalnamelist `" `byvalnamelist' `"`byvalname'"' "'
 		}
 		
 		


### PR DESCRIPTION
This pull requests fixes issue #1 . 

As described in the issue, whenever there is a space in a label value, the legend will break at each space. This is due to the extended macro `: word i of x` behaviour that  will treat space as word delimiter. 

To fix make sure one uses the whole label for each category one should wrap the labels with compounding quotes. I am not very well versed in Stata and find compounding quotes very hard to follow but after trying a few syntaxes, this commit should fix it. 

To get to this syntax I adapted from [Nick Cox's answer on StataList
](https://www.stata.com/statalist/archive/2012-08/msg00924.html),:

```
Stata's tendency is to strip " " as delimiters at each level of
parsing. To insist that " " are included as part of the token, I think
 you need to start with

local line `" `""AMC Concord""', 2, 4 "'
tokenize `"`line'"', parse(",")
 di `"`1'"'
```
But the added spaces around the local, as in 
```
local byvalnamelist `" `byvalnamelist' `"`byvalname'"' "'
```
seems to be necessary!

I am happy to try the fix with other datasets or more complex labels, if necessary. 
And, please, let me know if I should be doing anything differently (such as open a new branch for fixed, or anything like that) 
And at last but not least, thank you for writing the software!