### PR TITLE
Avoid matrix multiplication in binregselect_rot

### DIFF
--- a/Python/binsreg/src/binsreg/funs.py
+++ b/Python/binsreg/src/binsreg/funs.py
@@ -924,7 +924,7 @@ def binsregselect_rot(y, x, w, p, s, deriv, eN, es=False, norotnorm=False,
         cutval = norm.pdf(norm.ppf(den_alpha)*sig, loc = 0, scale = sig)
         fz[fz<cutval] = cutval
     if es: s2 = s2 / fz
-    else: s2 = s2 * (fz**(2*deriv))
+    else: s2 = s2 * np.transpose((fz**(2*deriv)))
     s2 = binsreg_summ(s2, w = weights, std=False)[0]
     vcons = imse_vcons(p, deriv)
     imse_v = vcons * s2


### PR DESCRIPTION
https://github.com/nppackages/binsreg/blob/a9e7b3091a62bffe5d883357342139d95d884fc2/Python/binsreg/src/binsreg/funs.py#L927 is timing out because it's trying to make a huge matrix multiplication. Compare to the R version which is doing it element-wise
https://github.com/nppackages/binsreg/blob/2f08dc70e73a5735e730228d4bceb227be42a936/R/binsreg/R/binsreg_functions.R#L294

so I propose to transpose the second vector: `fz**(2*deriv)`


I think this will fix the issue mentioned in https://github.com/nppackages/binsreg/pull/4 but with less change. Would be nice if you can merge this or https://github.com/nppackages/binsreg/pull/4. Would have saved me an hour of debugging! 