### PR TITLE
Use ** instead of ^ to raise to power in Python

### DIFF
--- a/Python/binsreg/src/binsreg/binsglm.py
+++ b/Python/binsreg/src/binsreg/binsglm.py
@@ -1359,7 +1359,7 @@ def binsglm(y, x, w=None, data=None, at=None, dist = 'Gaussian', link = None, de
                 basis_polyci = nanmat(npolyci_x, polyreg+1)
                 for j in range(polyreg+1):
                     if j>=deriv:
-                        basis_polyci[:,j] = polyci_x^(j-deriv)*factorial(j)/factorial(j-deriv)
+                        basis_polyci[:,j] = polyci_x**(j-deriv)*factorial(j)/factorial(j-deriv)
                     else:
                         basis_polyci[:,j] = np.zeros(npolyci_x)
                 

--- a/Python/binsreg/src/binsreg/binsqreg.py
+++ b/Python/binsreg/src/binsreg/binsqreg.py
@@ -1303,7 +1303,7 @@ def binsqreg(y, x, w=None, data=None, at=None, quantile=0.5, deriv=0,
                 basis_polyci = nanmat(npolyci_x, polyreg+1)
                 for j in range(polyreg+1):
                     if j>=deriv:
-                        basis_polyci[:,j] = polyci_x^(j-deriv)*factorial(j)/factorial(j-deriv)
+                        basis_polyci[:,j] = polyci_x**(j-deriv)*factorial(j)/factorial(j-deriv)
                     else:
                         basis_polyci[:,j] = np.repeat(0, npolyci_x)
                 

--- a/Python/binsreg/src/binsreg/binsreg.py
+++ b/Python/binsreg/src/binsreg/binsreg.py
@@ -1293,7 +1293,7 @@ def binsreg(y, x, w=None, data=None, at=None, deriv=0,
                 basis_polyci = nanmat(npolyci_x, polyreg+1)
                 for j in range(polyreg+1):
                     if j>=deriv:
-                        basis_polyci[:,j] = polyci_x^(j-deriv)*factorial(j)/factorial(j-deriv)
+                        basis_polyci[:,j] = polyci_x**(j-deriv)*factorial(j)/factorial(j-deriv)
                     else:
                         basis_polyci[:,j] = np.repeat(0, npolyci_x)
                 


### PR DESCRIPTION
Python uses ^ as the bitwise xor operator